### PR TITLE
page name comes first in browser tab

### DIFF
--- a/_layouts/base_page.html
+++ b/_layouts/base_page.html
@@ -15,7 +15,7 @@
 
     <script src="https://use.fontawesome.com/72b03f0302.js"></script>
 
-    <title> {{ page.title }} | RSS </title>
+    <title> {{ page.title }} | RS-Station </title>
 
   </head>
 

--- a/_layouts/base_page.html
+++ b/_layouts/base_page.html
@@ -15,7 +15,7 @@
 
     <script src="https://use.fontawesome.com/72b03f0302.js"></script>
 
-    <title>{{ site.title }} | {{ page.title }}</title>
+    <title> {{ page.title }} | RSS </title>
 
   </head>
 


### PR DESCRIPTION
"Reciprocal Space Station | {page name}" is too long to fit comfortably in a browser tab, especially with many tabs open. Tabs will now display "{page name} | RSS"

I could be talked into any number of other options, including:

- RSS | {page name}
- {page name}
- {page name} | RS-Station
- {page name} | Reciprocal Space Station
etc.