### PR TITLE
correct spelling of Maggie's last name

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -3,7 +3,7 @@
   url: https://www.biorxiv.org/content/10.1101/2021.01.05.425510v1
   info: Preprint
 - title: Native SAD phasing at room temperature
-  authors: "**Greisman, JB** and Kevin M. Dalton, Candice J. Sheehan, Margaret A. Klurexa, Igor Kurinov, Doeke R. Hekstra"
+  authors: "**Greisman, JB** and Kevin M. Dalton, Candice J. Sheehan, Margaret A. Klureza, Igor Kurinov, Doeke R. Hekstra"
   url: https://doi.org/10.1107/S2059798322006799
   info: Acta Crystallographica D, 2022
 - title: "*reciprocalspaceship*: a Python library for crystallographic data analysis"


### PR DESCRIPTION
Making a PR as best practice blah blah blah. Maggie's last name was listed as "Klurexa" in `publications.yml`, just fixing that.