### PR TITLE
Some discussed updates to the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,4 @@ title: Reciprocal Space Station
 plugins:
   - jekyll-font-awesome-sass
 
-port: 4500
+port: 4502

--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -1,9 +1,13 @@
 - name: reciprocalspaceship
-  link: https://github.com/Hekstra-Lab/reciprocalspaceship
+  link: https://github.com/rs-station/reciprocalspaceship
+  docs: https://rs-station.github.io/reciprocalspaceship/
   desc: Tools for exploring reciprocal space. This package provides a crystallographically-aware extension of `pandas` and other useful reciprocal-space tools
 - name: careless
-  link: https://github.com/Hekstra-Lab/careless
+  link: https://github.com/rs-station/careless
   desc: Applying variational inference to the scaling and merging of crystallographic data
 - name: rs-booster
   link: https://github.com/rs-station/rs-booster
   desc: A "booster rocket" for `reciprocalspaceship` containing useful command-line utilities
+- name: careless examples
+  link: https://github.com/rs-station/careless-examples
+  desc: Examples of `careless` usage

--- a/_includes/cards.html
+++ b/_includes/cards.html
@@ -9,9 +9,15 @@
                 <p class="card-text">{{ card.desc | markdownify }}</p>
             </div>
             <div class="card-footer">
+                {% if card.docs %}
+                <a class="btn btn-secondary btn-sm" href="{{ card.docs }}" >
+                    View Documentation
+                </a>
+                {% endif %}
                 <a class="btn btn-primary btn-sm" href="{{ card.link }}" >
                     View on GitHub
                 </a>
+
             </div>
         </div>
     </div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -21,7 +21,7 @@
 
                 <li class="nav-item">
                     <a class="nav-link"
-                        href="https://github.com/rs-station">
+                        href="https://github.com/orgs/rs-station/repositories">
                         <i class="fa fa-github"></i>
                     </a>
                 </li>

--- a/about.md
+++ b/about.md
@@ -6,4 +6,4 @@ layout: content_page
 # What is Reciprocal Space Station?
 Reciprocal Space Station (RSS) began in [Doeke Hekstra's lab](https://hekstralab.fas.harvard.edu/) with  `reciprocalspaceship`, a crystallographically-aware extension of the popular `pandas` python package.
 
-As `reciprocalspaceship` and other packages expanded and gained contributors outside of the Hekstra Lab, it became clear that it was time for Reciprocal Space Station to "take off" and become a separate organization. Our goal is for RSS to grow as a hub for open-source crystallographic software, gaining both new packages and new astronauts.
+As `reciprocalspaceship` and other packages expanded and gained contributors outside of the Hekstra Lab, it became time for Reciprocal Space Station to "take off" and become a separate organization. Our goal is for RSS to grow as a hub for open-source crystallographic software, gaining both new packages and new astronauts. 

--- a/contact.md
+++ b/contact.md
@@ -4,4 +4,7 @@ layout: content_page
 ---
 
 # Contact us
-Contact information coming soon
+
+If you have a question or suggestion about one of our software packages, the easiest thing do to is file an issue on [GitHub](https://github.com/orgs/rs-station/repositories). We would love your feedback, or even better, your contribution!
+
+For general questions, or if you'd like to get more involved, you can email us at [reciprocal-space-crew@googlegroups.com](mailto:reciprocal-space-crew@googlegroups.com)

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ layout: base_page
     <div class="col-md-5">
         <h1 class="font-weight-light">Reciprocal Space Station</h1>
         <p>Open source software for exploring reciprocal space</p>
-        <a class="btn btn-primary btn-sm" href="https://github.com/rs-station" >
+        <a class="btn btn-primary btn-sm" href="https://github.com/orgs/rs-station/repositories" >
                     View on GitHub
         </a>
     </div>


### PR DESCRIPTION
 - Added links to GitHub and google group email to Contact page, as discussed
 - Added a button on the home page to `rs` docs. Any other package with a `docs` attribute in `_data/packages.yml` will get this second button automatically. At some point I might switch the button colors so docs are blue and github links are grey, but for now, that would just make the packages without docs look sad :eyes:
 - Changed links on homepage and navbar referring to https://github.com/rs-station to instead refer to https://github.com/orgs/rs-station/repositories. I'm not sure why the former is such a weird landing page? But the latter is more what we're looking for I think. 
 - Changed a minor wording on the about us page that had been bugging me