### PR TITLE
Add careless paper and "how to cite" section

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,7 +1,7 @@
-- title: "Careless: A Variational Bayesian Model for Merging X-ray Diffraction Data"
+- title: "A unifying Bayesian framework for merging X-ray diffraction data"
   authors: "**Dalton, KM** and Jack B. Greisman, Doeke R. Hekstra"
-  url: https://www.biorxiv.org/content/10.1101/2021.01.05.425510v1
-  info: Preprint
+  url: https://www.nature.com/articles/s41467-022-35280-8
+  info: Nature Communications, 2022
 - title: Native SAD phasing at room temperature
   authors: "**Greisman, JB** and Kevin M. Dalton, Candice J. Sheehan, Margaret A. Klureza, Igor Kurinov, Doeke R. Hekstra"
   url: https://doi.org/10.1107/S2059798322006799

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,12 +1,15 @@
-- title: "A unifying Bayesian framework for merging X-ray diffraction data"
+- nickname: careless
+  title: "A unifying Bayesian framework for merging X-ray diffraction data"
   authors: "**Dalton, KM** and Jack B. Greisman, Doeke R. Hekstra"
   url: https://www.nature.com/articles/s41467-022-35280-8
   info: Nature Communications, 2022
-- title: Native SAD phasing at room temperature
+- nickname: rtsad
+  title: Native SAD phasing at room temperature
   authors: "**Greisman, JB** and Kevin M. Dalton, Candice J. Sheehan, Margaret A. Klureza, Igor Kurinov, Doeke R. Hekstra"
   url: https://doi.org/10.1107/S2059798322006799
   info: Acta Crystallographica D, 2022
-- title: "*reciprocalspaceship*: a Python library for crystallographic data analysis"
+- nickname: rs
+  title: "*reciprocalspaceship*: a Python library for crystallographic data analysis"
   authors: "**Greisman, JB** and Kevin M. Dalton, Doeke R. Hekstra"
   url: https://scripts.iucr.org/cgi-bin/paper?S160057672100755X
   info: Journal of Applied Crystallography, 2021

--- a/publications.md
+++ b/publications.md
@@ -10,6 +10,20 @@ The following publications make use of RSS packages. If there's a paper we're mi
  - [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}
 
-## Citing RSS packages
+## How to cite
+If you're making use of any RSS packages, amazing! Please cite them as follows:
 
-Information about citing RSS packages coming soon! In the mean time, if you're using an RSS package in your work, please [reach out to us directly](/contact.html)
+### ReciprocalSpaceship
+{% assign rspub = site.data.publications | where: "nickname", "rs" %}
+{% for pub in rspub %}
+[{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
+{% endfor %}
+
+### Careless
+{% assign clpub = site.data.publications | where: "nickname", "careless" %}
+{% for pub in clpub %}
+[{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
+{% endfor %}
+
+### RS-booster
+[Cite GitHub directly](https://github.com/rs-station/rs-booster)


### PR DESCRIPTION
Updating the careless paper was straightforward. My question is what to do with the "how to cite" section, which has been tbd up until now; I was waiting for the careless paper to go live. 

The liquid syntax can be a little hard to parse, so I've included a screenshot of what the page will look like (from my local test build of the site). Does this seem roughly correct? Is there anything else we should say here? I tend to think that a "how to cite" section is one of the more important parts of this website, and I don't want to be leading folks astray.

The screenshot:
---
<img width="738" alt="Screen Shot 2022-12-15 at 11 27 22 AM" src="https://user-images.githubusercontent.com/61811696/207914863-e0ff076e-4d1e-466f-a463-0cdd5c23aebe.png">
