### PR TITLE
add bare-bones installation instructions

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -6,3 +6,5 @@
   link: /contact.html
 - name: Publications
   link: /publications.html
+- name: Installation
+  link: /installation.html

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -310,6 +310,8 @@ pre code {
   font-size: inherit;
   color: inherit;
   word-break: normal;
+  display: block;
+  margin-left: 12px;
 }
 
 code {

--- a/installation.md
+++ b/installation.md
@@ -1,0 +1,40 @@
+---
+title: Installation
+layout: content_page
+---
+
+# How to install
+
+All of the Reciprocal Space Station packages are `pip`-installable, e.g.:
+
+```bash
+pip install reciprocalspaceship
+```
+
+We recommend that you use a package manager such as [`conda`](https://docs.conda.io/en/latest/) and always install into a fresh environment, e.g.:
+
+```bash
+conda create -n my-new-careless-environment
+conda activate my-new-careless-environment
+pip install careless
+```
+
+## Development builds
+
+If you're looking for a version of the software that's newer than the latest version published to PyPI, you can alternatively install directly from source:
+
+```bash
+pip install git+https://github.com/rs-station/rs-booster.git
+```
+
+or if you want to develop yourself and use your own custom version, you can clone the source code:
+
+```bash
+git clone https://github.com/rs-station/rs-booster.git
+cd rs-booster
+pip install -e .
+```
+
+## Companion software
+
+The pure-python dependencies of RSS packages (`numpy`, `pandas`, `gemmi`, etc.) will be downloaded automatically when you use `pip`. However, some functionality (e.g. [`rs.scaleit`](https://rs-station.github.io/rs-booster/misc.html#id1) from `rs-booster`) is just a wrapper around other software (in this case, [`CCP4`](https://www.ccp4.ac.uk/download/#os=mac)) which does need to be installed separately. Hopefully, some day soon, software such as `CCP4` and `phenix` will follow the lead of `dials`, `gemmi`, `cctbx`, and more and become `pip`/`conda`-installable!


### PR DESCRIPTION
I realized that, while each individual package had installation instructions somewhere, it made sense to have an "installation instructions" page on the overall site as well.

This felt especially prudent because I realized that the implicit CCP4 dependency of `rs.scaleit` wasn't really stated anywhere. I'm also planning on adding some new code at some point with phenix as a dependency as well.

I don't _**love**_ the way that code blocks are styled by default; I added a little bit of indentation, which is better, but I'm open to suggestions if anyone knows a slick CSS trick for styling a `<pre>`/`<code>` block.