### PR TITLE
Adding laue-dials and abismal to website

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -5,6 +5,10 @@
 - name: careless
   link: https://github.com/rs-station/careless
   desc: Applying variational inference to the scaling and merging of crystallographic data
+- name: matchmaps
+  link: https://github.com/rs-station/matchmaps
+  docs: https://rs-station.github.io/matchmaps/
+  desc: Make difference maps between near-isomorphous or non-isomorphous datasets
 - name: laue-dials
   link: https://github.com/rs-station/laue-dials
   desc: Extending `DIALS` for polychromatic "pink beam" data collected at Laue X-ray sources

--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -12,9 +12,9 @@
 - name: laue-dials
   link: https://github.com/rs-station/laue-dials
   desc: Extending `DIALS` for polychromatic "pink beam" data collected at Laue X-ray sources
-- name: abismal
-  link: https://github.com/rs-station/abismal
-  desc: "**A**pproximate **B**ayesian **I**nference for **S**caling and **M**erging at **A**dvanced **L**ightsources"
+#- name: abismal
+#  link: https://github.com/rs-station/abismal
+#  desc: "**A**pproximate **B**ayesian **I**nference for **S**caling and **M**erging at **A**dvanced **L**ightsources"
 - name: rs-booster
   link: https://github.com/rs-station/rs-booster
   docs: https://rs-station.github.io/rs-booster/

--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -5,6 +5,12 @@
 - name: careless
   link: https://github.com/rs-station/careless
   desc: Applying variational inference to the scaling and merging of crystallographic data
+- name: laue-dials
+  link: https://github.com/rs-station/laue-dials
+  desc: Extending `DIALS` for polychromatic "pink beam" data collected at Laue X-ray sources
+- name: abismal
+  link: https://github.com/rs-station/abismal
+  desc: "**A**pproximate **B**ayesian **I**nference for **S**caling and **M**erging at **A**dvanced **L**ightsources"
 - name: rs-booster
   link: https://github.com/rs-station/rs-booster
   docs: https://rs-station.github.io/rs-booster/

--- a/publications.md
+++ b/publications.md
@@ -15,17 +15,23 @@ The following publications make use of RSS packages. If there's a paper we're mi
 ## How to cite
 If you're making use of any RSS packages, amazing! Please cite them as follows:
 
-### ReciprocalSpaceship
+### reciprocalspaceship
 {% assign rspub = site.data.publications | where: "nickname", "rs" %}
 {% for pub in rspub %}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}
 
-### Careless
+### careless
 {% assign clpub = site.data.publications | where: "nickname", "careless" %}
 {% for pub in clpub %}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}
 
-### RS-booster
+### laue-dials
+[Cite GitHub directly](https://github.com/rs-station/laue-dials)
+
+### abismal
+[Cite GitHub directly](https://github.com/rs-station/abismal)
+
+### rs-booster
 [Cite GitHub directly](https://github.com/rs-station/rs-booster)


### PR DESCRIPTION
My general philosophy here is that once a package is ready enough to be potentially useful to an outside user, it should be on the website. To that end, this PR adds `laue-dials` and `abismal` to the website.

If anyone strongly objects to this, let me know! I could also imagine somehow dividing the website into "packages" vs. "beta packages" in a way that's informative, if folks feel better about that.

Specifically, of course, I'd love input from @kmdalton and @PrinceWalnut about if they think this makes sense! @DHekstra 's opinion is always valued as well, of course.