### PR TITLE
add laue-dials docs to website

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -11,6 +11,7 @@
   desc: Make difference maps between near-isomorphous or non-isomorphous datasets
 - name: laue-dials
   link: https://github.com/rs-station/laue-dials
+  docs: https://rs-station.github.io/laue-dials/
   desc: Extending `DIALS` for polychromatic "pink beam" data collected at Laue X-ray sources
 #- name: abismal
 #  link: https://github.com/rs-station/abismal


### PR DESCRIPTION
Now that `laue-dials` has a website, it should be linked in the Reciprocal Space Station homepage.