### PR TITLE
Give blog a card on the home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,4 @@ title: Reciprocal Space Station
 plugins:
   - jekyll-font-awesome-sass
 
-port: 4500
+port: 4501

--- a/_includes/cards.html
+++ b/_includes/cards.html
@@ -1,5 +1,21 @@
 <div class="row gx-4 gx-lg-5">
 
+    <div class="col-md-4 mb-5">
+        <div class="card h-100 blog">
+            <div class="card-body">
+                <h2 class="card-title">Blog</h2>
+                <p class="card-text">Explanations, elaborations, and more about crystallographic data analysis, written by the 1/astronauts </p>
+            </div>
+            <div class="blog-footer">
+
+                <a class="btn btn-primary btn-sm" href="/blog.html" >
+                    See blog posts
+                </a>
+
+            </div>
+        </div>
+    </div>
+
     {% for card in site.data.packages %}
 
     <div class="col-md-4 mb-5">

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -5326,6 +5326,16 @@ fieldset:disabled .btn {
   padding: 1rem 1rem;
 }
 
+.blog {
+  background-color: #b6d3fe ;
+}
+
+.blog-footer {
+  padding: 0.5rem 1rem;
+  background-color:  #9ec5fe;
+  border-top: 1px solid rgba(0, 0, 0, 0.125);
+}
+
 .card-title {
   margin-bottom: 0.5rem;
 }
@@ -5360,7 +5370,7 @@ fieldset:disabled .btn {
   border-top: 1px solid rgba(0, 0, 0, 0.125);
 }
 
-.card-footer:last-child {
+.card-footer:last-child,.blog-footer:last-child {
   border-radius: 0 0 calc(0.25rem - 1px) calc(0.25rem - 1px);
 }
 

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ layout: base_page
     <div class="col-md-5">
         <h1 class="font-weight-light">Reciprocal Space Station</h1>
         <p>Open source software for exploring reciprocal space</p>
-        <a class="btn btn-primary btn-sm" href="https://github.com/orgs/rs-station/repositories" >
+        <a class="btn btn-primary btn-sm" href="https://github.com/orgs/rs-station" >
                     View on GitHub
         </a>
     </div>


### PR DESCRIPTION
Doeke pointed out that the existence of the blog was tucked away in the top corner and not mentioned anywhere else. Here, I made a new "card" on the home page which links to the blog. This card is blue for extra emphasis; pulling this off required some minor changes to the CSS. For aesthetics, the blues used are both lighter hues of the blue used in the "View on Github" buttons