### PR TITLE
Add new preprints to website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,4 @@ title: Reciprocal Space Station
 plugins:
   - jekyll-font-awesome-sass
 
-port: 4501
+port: 4502

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,13 +1,37 @@
+- nickname: dj1
+  title: "Resolving DJ-I glyoxalase catalysis using mix-and-inject serial crystallography at a synchrotron"
+  first_author: "Zielinski"
+  authors: "**, Kara A.** and Cole Dolamore, Kevin M. Dalton, Nathan Smith, John Termini, Robert Henning, Vukica Srajer, Doeke R. Hekstra, Lois Pollack, Mark A. Wilson"
+  url: https://www.biorxiv.org/content/10.1101/2024.07.19.604369v1
+  info: bioRxiv (preprint)
+- nickname: trxvaritional
+  title: "Scaling and merging time-resolved Laue data with variational inference"
+  first_author: "Zielinski"
+  authors: "**, Kara A.** and Cole Dolamore, Harrison K. Wang, Robert W. Henning, Mark A. Wilson, Lois Pollack, Vukica Srajer, Doeke R. Hekstra, Kevin M. Dalton"
+  url: https://www.biorxiv.org/content/10.1101/2024.07.30.605871v1
+  info: bioRxiv (preprint)
+- nickname: doublewilson
+  title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
+  first_author: "Hekstra"
+  authors: "**, Doeke R.** and Harrison K. Wang, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
+  url: https://www.biorxiv.org/content/10.1101/2024.07.22.604476v1
+  info: bioRxiv (preprint)
+- nickname: lauedials
+  title: "Laue-DIALS: open-source software for polychromatic X-ray diffraction data"
+  first_author: "Hewitt"
+  authors: "**, Rick A.** and Kevin M. Dalton, Derek Mendez, Harrison K. Wang, Margaret A. Klureza, Dennis E. Brookner, Jack B. Greisman, David McDonagh, Vukica Šrajer, Nicholas K. Sauter, Aaron S. Brewster, Doeke R. Hekstra"
+  url: https://www.biorxiv.org/content/10.1101/2024.07.23.604358v1
+  info: bioRxiv (preprint)
 - nickname: jackdhfr
   title: "Perturbative diffraction methods resolve a conformational switch that facilitates a two-step enzymatic mechanism"
   first_author: "Greisman"
-  authors: "**, Jack B.** Kevin M. Dalton, Dennis E. Brookner, Margaret A. Klureza, Candice J. Sheehan, In-Sik Kim, Robert W. Henning, Silvia Russi, Doeke R. Hekstra"
+  authors: "**, Jack B.** and Kevin M. Dalton, Dennis E. Brookner, Margaret A. Klureza, Candice J. Sheehan, In-Sik Kim, Robert W. Henning, Silvia Russi, Doeke R. Hekstra"
   url: https://www.pnas.org/doi/abs/10.1073/pnas.2313192121
   info: PNAS, 2024
 - nickname: matchmaps
   title: "MatchMaps: non-isomorphous difference maps for X-ray crystallography"
   first_author: "Brookner"
-  authors: "**, Dennis E.** and Doeke R, Hekstra"
+  authors: "**, Dennis E.** and Doeke R. Hekstra"
   url: https://journals.iucr.org/j/issues/2024/03/00/ei5112/index.html
   info: Journal of Applied Crystallography, 2024
 - nickname: trxreview

--- a/publications.md
+++ b/publications.md
@@ -27,14 +27,17 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 [{{ pub.title }}]({{ pub.url}}). **{{ pub.first_author }}**{{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}
 
+### laue-dials
+{% assign ldpub = site.data.publications | where: "nickname", "lauedials" %}
+{% for pub in ldpub %}
+[{{ pub.title }}]({{ pub.url}}). **{{ pub.first_author }}**{{ pub.authors }}. *{{ pub.info }}*
+{% endfor %}
+
 ### matchmaps
 {% assign mmpub = site.data.publications | where: "nickname", "matchmaps" %}
 {% for pub in mmpub %}
 [{{ pub.title }}]({{ pub.url}}). **{{ pub.first_author }}**{{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}
-
-### laue-dials
-[Cite GitHub directly](https://github.com/rs-station/laue-dials)
 
 ### abismal
 [Cite GitHub directly](https://github.com/rs-station/abismal)


### PR DESCRIPTION
This PR adds the four new RSS-related preprints to the publications page of the website. It also specifies that Laue-DIALS should be cited via the relevant paper.

I will note that the publications page is getting a little crowded. An exciting problem, of course, and I don't think it's an immediate concern, but we could consider some sort of reorganization. For example, I think it's within my jekyll abilities to parse the citation data and make a subheading for each year.