### PR TITLE
add "back to blog" button at top and bottom of posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,9 +1,13 @@
 ---
 layout: content_page
 ---
+<p><a href="/blog.html">⬅️ Back to blog posts</a></p>
+
 <p>{{ page.date | date_to_string }}</p>
 <h1>{{ page.title }}</h1>
 <h3>{{ page.subtitle }}</h3>
 <p>{{ page.author }}</p>
 
 {{ content }}
+
+<p><a href="/blog.html">⬅️ Back to blog posts</a></p>


### PR DESCRIPTION
Just a tiny change because this was bothering me!

This PR adds a "⬅️ Back to blog posts" link at the top and bottom of each blog post. The change is made to the `_layouts/posts.html` file such that it applies to all current and future posts automatically.

I think this is pretty standard, e.g. it feels weird on a website to have to use the main menu bar (or the browser back arrow) to navigate the site hierarchy. Let me know if anyone has any thoughts!