### PR TITLE
Revert "Add slack invite link to contact"

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -7,4 +7,4 @@ layout: content_page
 
 If you have a question or suggestion about one of our software packages, the easiest thing do to is file an issue on [GitHub](https://github.com/orgs/rs-station/repositories). We would love your feedback, or even better, your contribution!
 
-For general questions, or if you'd like to get more involved, join us on the [RS-Station Slack workspace](join-slack.html) or email us at [reciprocal-space-crew@googlegroups.com](mailto:reciprocal-space-crew@googlegroups.com)
+For general questions, or if you'd like to get more involved, you can email us at [reciprocal-space-crew@googlegroups.com](mailto:reciprocal-space-crew@googlegroups.com)

--- a/join-slack.html
+++ b/join-slack.html
@@ -1,5 +1,0 @@
----
-title: Join the RS-Station Slack Workspace
-slack-invite-url: https://join.slack.com/t/reciprocalspa-cfs9659/shared_invite/zt-2ofzbj1j6-kFE~zYvL7R~4lVwXpUpOUQ
----
-<meta http-equiv="refresh" content="0; url={{ page.slack-invite-url }}" />


### PR DESCRIPTION
Reverts rs-station/rs-station.github.io#26 because Slack invite links never require admin approval. 