### PR TITLE
Bump artifact version

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,7 +34,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:

--- a/.github/workflows/build_only.yml
+++ b/.github/workflows/build_only.yml
@@ -34,5 +34,5 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
        


### PR DESCRIPTION
As per [this article](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), the `upload-pages-artifact` action is now required to be v4 or higher. We were still using v1 !!!

This is why the workflow in #36 is failing.