### PR TITLE
add sfcalculator card and citation

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -23,6 +23,11 @@
   link: https://github.com/rs-station/rs-booster
   docs: https://rs-station.github.io/rs-booster/
   desc: A "booster rocket" for `reciprocalspaceship` containing useful command-line utilities
+- name: SFCalculator
+  type: production
+  link: https://github.com/Hekstra-Lab/SFcalculator_torch
+  docs: https://hekstra-lab.github.io/SFcalculator_torch/
+  desc: A differentiable pipeline connecting the protein atomic models and experimental structure factors, featuring a differentiable bulk solvent correction.
 - name: abismal
   type: development
   link: https://github.com/rs-station/abismal

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -82,3 +82,10 @@
   authors: "**, Jack B.** and Kevin M. Dalton, Doeke R. Hekstra"
   url: https://scripts.iucr.org/cgi-bin/paper?S160057672100755X
   info: Journal of Applied Crystallography, 2021
+- nickname: SFCalculator
+  section: cite
+  title: "SFCalculator: connecting deep generative models and crystallography"
+  first_author: "Minhuan Li"
+  authors: ", Kevin M. Dalton, Doeke R. Hekstra"
+  url: https://doi.org/10.1101/2025.01.12.632630 
+  info: BioRxiv, 2025

--- a/publications.md
+++ b/publications.md
@@ -30,6 +30,12 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 [{{ pub.title }}]({{ pub.url}}). **{{ pub.first_author }}**{{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}
 
+### SFCalculator
+{% assign sfpub = site.data.publications | where: "nickname", "SFCalculator" %}
+{% for pub in sfpub %}
+[{{ pub.title }}]({{ pub.url}}). **{{ pub.first_author }}**{{ pub.authors }}. *{{ pub.info }}*
+{% endfor %}
+
 ### abismal
 [Cite GitHub directly](https://github.com/rs-station/abismal)
 


### PR DESCRIPTION
This PR adds a card for SFCalculator to the main page and the BioRxiv preprint to the citations page. 