### PR TITLE
update citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Reciprocal Space Station encourages developers to contribute [blog posts](rs-sta
         ![Systematic errors in rotation data](/assets/posts/2024-07-31-multivariate-wilson/systematic_error.png){: .blog-image} 
         Example of systematic errors in conventional diffraction data from [Dalton et al](https://doi.org/10.1038/s41467-022-35280-8). [(CC-BY license)](https://creativecommons.org/licenses/by/4.0/)
         {: .blog-caption}
- - Inlude the licenses of images from papers or preprints.
+ - Include the licenses of images from papers or preprints.
 
 For simple posts without figures or equations, you might not need a preview. For information about previewing changes, see [below](#previewing-website-changes)
 
@@ -46,7 +46,7 @@ For other publications that were written by reciprocal astronauts and/or using r
 
 ```yml
 - nickname: reckless
-  section: pubs
+  section: applications
   title: Online Maximization of Paperclips
   authors: "**Devin M. Bolton**, Zach B. Micemen, Derk R. Hoekstra"
   url: https://doi.org/1l.1111/2033.01.12.632630
@@ -65,7 +65,7 @@ There are two ways to get a preview of website changes before they go live onlin
 
 #### Notes for writing HTML
 
-Note that the syntactical sugar described here is only necessary when writting HTML, and can be ignored entirely when writing markdown.
+Note that the syntactical sugar described here is only necessary when writing HTML, and can be ignored entirely when writing markdown.
 
 The HTML infrastructure of the website is written such that the exact same code can build the website either at rs-station.github.io **or** rs-station.github.io/website-test. In order for this to work, HTML links must be specified as *relative* links with the following [Jekyll](https://jekyllrb.com/)/[Liquid](https://shopify.github.io/liquid/basics/introduction/) syntax:
 
@@ -86,7 +86,7 @@ You can find all the instances of this syntax by searching this repo for "relati
 
 #### Building Jekyll locally
 
-The second (and not recommended) option is to run [Jekyll](https://jekyllrb.com/) yourself to build your own local copy of the site. Follow these instructions to serve the rs-station page locally for writing or development; be warned that this may involve a fair amount of setup and isntallation. 
+The second (and not recommended) option is to run [Jekyll](https://jekyllrb.com/) yourself to build your own local copy of the site. Follow these instructions to serve the rs-station page locally for writing or development; be warned that this may involve a fair amount of setup and installation. 
  1. Install ruby and Jekyll by following the [instructions](https://jekyllrb.com/docs/) in the  Jekyll docs
  2. Install the `rs-station` specific dependencies by running: `gem install jekyll-font-awesome-sass github-pages`
  3. To start serving the site, run `bundle exec jekyll serve --livereload` in your local `rs-station.github.io` git repository

--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ The key differences are that the "section" value is different and that "cite" en
 
 ### Previewing website changes
 
-There are two ways to get a preview of website changes before they go live online. The recommended method is to consult the test clone of the website, which lives online at rs-station.github.io/website-test. The test website is re-built automatically any time there is a pull request into the main branch of this repo. Any issues in content or formatting should be apparent from the test build, and these issues can be updated before the changes go live on the actual website. For contributing a blog post, this is all you should need to know!
+There are two ways to get a preview of website changes before they go live online. 
+
+#### [Test build of the website](rs-station.github.io/website-test)
+
+The test website is re-built automatically any time there is a pull request into the main branch of this repo. Any issues in content or formatting should be apparent from the test build, and these issues can be updated before the changes go live on the actual website. 
+
+For contributing a blog post, this is all you should need to know!
 
 #### Notes for writing HTML
 

--- a/README.md
+++ b/README.md
@@ -61,38 +61,9 @@ The key differences are that the "section" value is different and that "cite" en
 
 ### Previewing website changes
 
-There are two ways to get a preview of website changes before they go live online. 
-
-#### [Test build of the website](rs-station.github.io/website-test)
-
-The test website is re-built automatically any time there is a pull request into the main branch of this repo. Any issues in content or formatting should be apparent from the test build, and these issues can be updated before the changes go live on the actual website. 
-
-For contributing a blog post, this is all you should need to know!
-
-#### Notes for writing HTML
-
-Note that the syntactical sugar described here is only necessary when writing HTML, and can be ignored entirely when writing markdown.
-
-The HTML infrastructure of the website is written such that the exact same code can build the website either at rs-station.github.io **or** rs-station.github.io/website-test. In order for this to work, HTML links must be specified as *relative* links with the following [Jekyll](https://jekyllrb.com/)/[Liquid](https://shopify.github.io/liquid/basics/introduction/) syntax:
-
-```html
-<a class="navbar-brand" href="{{ '/index.html' | relative_url}}"> 
-```
-This link will point to rs-station.github.io/index on the actual site, and to rs-station.github.io/website-test/index on the test site, as desired.
-
-It is **incorrect** for any HTML links to be specified like this:
-
-```html
-<!-- this does not work! do not do this! -->
-<a class="navbar-brand" href="/index.html"> 
-```
-because this link will always point to rs-station.github.io/index, even when it is supposed to point to rs-station.github.io/website-test/index.
-
-You can find all the instances of this syntax by searching this repo for "relative_url".
-
 #### Building Jekyll locally
 
-The second (and not recommended) option is to run [Jekyll](https://jekyllrb.com/) yourself to build your own local copy of the site. Follow these instructions to serve the rs-station page locally for writing or development; be warned that this may involve a fair amount of setup and installation. 
+Run [Jekyll](https://jekyllrb.com/) yourself to build your own local copy of the site. Follow these instructions to serve the rs-station page locally for writing or development; be warned that this may involve a fair amount of setup and installation. 
  1. Install ruby and Jekyll by following the [instructions](https://jekyllrb.com/docs/) in the  Jekyll docs
  2. Install the `rs-station` specific dependencies by running: `gem install jekyll-font-awesome-sass github-pages`
  3. To start serving the site, run `bundle exec jekyll serve --livereload` in your local `rs-station.github.io` git repository

--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -28,11 +28,12 @@
   link: https://github.com/Hekstra-Lab/SFcalculator_torch
   docs: https://hekstra-lab.github.io/SFcalculator_torch/
   desc: A differentiable pipeline connecting the protein atomic models and experimental structure factors, featuring a differentiable bulk solvent correction.
+- name: ☄️ METEOR
+  type: production
+  link: https://github.com/rs-station/meteor
+  desc: "**M**ap **E**nhancement **T**ools for **E**phemeral **O**ccupancy **R**efinement is a tool for computing crystallographic difference maps."
 - name: abismal
   type: development
   link: https://github.com/rs-station/abismal
   desc: "**A**pproximate **B**ayesian **I**nference for **S**caling and **M**erging at **A**dvanced **L**ightsources"
-- name: ☄️ METEOR
-  type: development
-  link: https://github.com/rs-station/meteor
-  desc: "**M**ap **E**nhancement **T**ools for **E**phemeral **O**ccupancy **R**efinement is a tool for computing crystallographic difference maps."
+

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -7,7 +7,7 @@
 - nickname: meteor
   section: pubs
   title: "Denoising and iterative phase recovery reveal low-occupancy populations in protein crystals"
-  authors: "**Alisia Fadini **, Virginia Apostolopoulou, Thomas J. Lane, Jasper J. van Thor"
+  authors: "**Alisia Fadini**, Virginia Apostolopoulou, Thomas J. Lane, Jasper J. van Thor"
   url: https://doi.org/10.1038/s42003-025-09031-6
   info: Communications Biology, 2025
 - nickname: rocket

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,77 +1,28 @@
 - nickname: doublewilson
-  section: pubs
+  section: cite
   title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
   authors: "**Doeke R. Hekstra**, Harrison K. Wang, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
   url: https://doi.org/10.1126/sciadv.adj2921 
   info: Science Advances, 2025
 - nickname: meteor
-  section: pubs
+  section: cite
   title: "Denoising and iterative phase recovery reveal low-occupancy populations in protein crystals"
   authors: "**Alisia Fadini**, Virginia Apostolopoulou, Thomas J. Lane, Jasper J. van Thor"
   url: https://doi.org/10.1038/s42003-025-09031-6
   info: Communications Biology, 2025
 - nickname: rocket
-  section: pubs
+  section: cite
   title: "AlphaFold as a Prior: Experimental Structure Determination Conditioned on a Pretrained Neural Network"
   authors: "**Alisia Fadini**, **Minhuan Li**, Airlie J. McCoy, Thomas C. Terwilliger, Randy J. Read, Doeke Hekstra, Mohammed AlQuraishi"
   url:  https://doi.org/10.1101/2025.02.18.638828 
   info: bioRxiv (preprint), 2025
-- nickname: carelessED
-  section: pubs
-  title: "Assessing the applicability of Bayesian inference for merging small molecule microED data"
-  authors: "Huanghao Mai, Ariana Peck, Kevin M. Dalton, Lygia Silva de Moraes, Jessica E. Burch, Frédéric Poitevin, Hosea M. Nelson"
-  url: https://doi.org/10.26434/chemrxiv-2024-62bmk
-  info: chemRxiv (preprint), 2024
-- nickname: dj1
-  section: pubs
-  title: "Resolving DJ-I glyoxalase catalysis using mix-and-inject serial crystallography at a synchrotron"
-  authors: "**Kara A. Zielinski and Cole Dolamore**, Kevin M. Dalton, Nathan Smith, John Termini, Robert Henning, Vukica Srajer, Doeke R. Hekstra, Lois Pollack, Mark A. Wilson"
-  url:  https://doi.org/10.1101/2024.07.19.604369
-  info: bioRxiv (preprint), 2024
-- nickname: trxvaritional
-  section: pubs
-  title: "Scaling and merging time-resolved Laue data with variational inference"
-  authors: "**Kara A. Zielinski**, Cole Dolamore, Harrison K. Wang, Robert W. Henning, Mark A. Wilson, Lois Pollack, Vukica Srajer, Doeke R. Hekstra, Kevin M. Dalton"
-  url: https://doi.org/10.1063/4.0000269
-  info: Structural Dynamics, 2024
-- nickname: lauedials
+- nickname: SFCalculator
   section: cite
-  package: "Laue-DIALS"
-  title: "Laue-DIALS: open-source software for polychromatic X-ray diffraction data"
-  authors: "**Rick A. Hewitt**, Kevin M. Dalton, Derek Mendez, Harrison K. Wang, Margaret A. Klureza, Dennis E. Brookner, Jack B. Greisman, David McDonagh, Vukica Šrajer, Nicholas K. Sauter, Aaron S. Brewster, Doeke R. Hekstra"
-  url: https://doi.org/10.1063/4.0000265
-  info: Structural Dynamics, 2024
-- nickname: jackdhfr
-  section: pubs
-  title: "Perturbative diffraction methods resolve a conformational switch that facilitates a two-step enzymatic mechanism"
-  authors: "**Jack B. Greisman**, Kevin M. Dalton, Dennis E. Brookner, Margaret A. Klureza, Candice J. Sheehan, In-Sik Kim, Robert W. Henning, Silvia Russi, Doeke R. Hekstra"
-  url: https://doi.org/10.1073/pnas.2313192121
-  info: PNAS, 2024
-- nickname: matchmaps
-  section: cite
-  package: "MatchMaps"
-  title: "MatchMaps: non-isomorphous difference maps for X-ray crystallography"
-  authors: "**Dennis E. Brookner** and Doeke R. Hekstra"
-  url: https://doi.org/10.1107/S1600576724003510
-  info: Journal of Applied Crystallography, 2024
-- nickname: trxreview
-  section: pubs
-  title: "Emerging Time-Resolved X-Ray Diffraction Approaches for Protein Dynamics"
-  authors: "**Doeke R. Hekstra**"
-  url: https://doi.org/10.1146/annurev-biophys-111622-091155
-  info: Annu. Rev. Biophys., 2023
-- nickname: scaling
-  section: pubs
-  title: "Correcting systematic errors in diffraction data with modern scaling algorithms"
-  authors: "**Luis A. Aldama and Kevin M. Dalton**, Doeke R. Hekstra"
-  url: https://doi.org/10.1107/S2059798323005776
-  info: Acta Crystallographica D, 2023
-- nickname: neurips2022
-  section: pubs
-  title: "Online Inference of Structure Factor Amplitudes for Serial X-ray Crystallography"
-  authors: "**Kevin M. Dalton** and Doeke R. Hekstra"
-  url: https://www.mlsb.io/papers_2022/Online_Inference_of_Structure_Factor_Amplitudes_for_Serial_X_ray_Crystallography.pdf
-  info: Machine Learning for Structural Biology Workshop, NeurIPS 2022
+  package: "SFCalculator"
+  title: "SFCalculator: connecting deep generative models and crystallography"
+  authors: "**Minhuan Li**, Kevin M. Dalton, Doeke R. Hekstra"
+  url: https://doi.org/10.1101/2025.01.12.632630 
+  info: bioRxiv (preprint), 2025
 - nickname: careless
   section: cite
   package: "Careless"
@@ -79,12 +30,20 @@
   authors: "**Kevin M. Dalton**, Jack B. Greisman, Doeke R. Hekstra"
   url: https://doi.org/10.1038/s41467-022-35280-8
   info: Nature Communications, 2022
-- nickname: rtsad
-  section: pubs
-  title: Native SAD phasing at room temperature
-  authors: "**Jack B. Greisman**, Kevin M. Dalton, Candice J. Sheehan, Margaret A. Klureza, Igor Kurinov, Doeke R. Hekstra"
-  url: https://doi.org/10.1107/S2059798322006799
-  info: Acta Crystallographica D, 2022
+- nickname: matchmaps
+  section: cite
+  package: "MatchMaps"
+  title: "MatchMaps: non-isomorphous difference maps for X-ray crystallography"
+  authors: "**Dennis E. Brookner** and Doeke R. Hekstra"
+  url: https://doi.org/10.1107/S1600576724003510
+  info: Journal of Applied Crystallography, 2024
+- nickname: lauedials
+  section: cite
+  package: "Laue-DIALS"
+  title: "Laue-DIALS: open-source software for polychromatic X-ray diffraction data"
+  authors: "**Rick A. Hewitt**, Kevin M. Dalton, Derek Mendez, Harrison K. Wang, Margaret A. Klureza, Dennis E. Brookner, Jack B. Greisman, David McDonagh, Vukica Šrajer, Nicholas K. Sauter, Aaron S. Brewster, Doeke R. Hekstra"
+  url: https://doi.org/10.1063/4.0000265
+  info: Structural Dynamics, 2024
 - nickname: rs
   section: cite
   package: "reciprocalspaceship"
@@ -92,13 +51,6 @@
   authors: "**Jack B. Greisman**, Kevin M. Dalton, Doeke R. Hekstra"
   url: https://doi.org/10.1107/S160057672100755X
   info: Journal of Applied Crystallography, 2021
-- nickname: SFCalculator
-  section: cite
-  package: "SFCalculator"
-  title: "SFCalculator: connecting deep generative models and crystallography"
-  authors: "**Minhuan Li**, Kevin M. Dalton, Doeke R. Hekstra"
-  url: https://doi.org/10.1101/2025.01.12.632630 
-  info: bioRxiv (preprint)
 - nickname: abismal
   section: cite
   package: "ABISMAL"
@@ -113,3 +65,51 @@
   authors: "**1 / Astronauts**"
   url: https://github.com/rs-station/rs-booster
   info: GitHub, 2025
+- nickname: carelessED
+  section: uses
+  title: "Assessing the applicability of Bayesian inference for merging small molecule microED data"
+  authors: "Huanghao Mai, Ariana Peck, Kevin M. Dalton, Lygia Silva de Moraes, Jessica E. Burch, Frédéric Poitevin, Hosea M. Nelson"
+  url: https://doi.org/10.26434/chemrxiv-2024-62bmk
+  info: chemRxiv (preprint), 2024
+- nickname: dj1
+  section: uses
+  title: "Resolving DJ-I glyoxalase catalysis using mix-and-inject serial crystallography at a synchrotron"
+  authors: "**Kara A. Zielinski and Cole Dolamore**, Kevin M. Dalton, Nathan Smith, John Termini, Robert Henning, Vukica Srajer, Doeke R. Hekstra, Lois Pollack, Mark A. Wilson"
+  url:  https://doi.org/10.1101/2024.07.19.604369
+  info: bioRxiv (preprint), 2024
+- nickname: trxvaritional
+  section: uses
+  title: "Scaling and merging time-resolved Laue data with variational inference"
+  authors: "**Kara A. Zielinski**, Cole Dolamore, Harrison K. Wang, Robert W. Henning, Mark A. Wilson, Lois Pollack, Vukica Srajer, Doeke R. Hekstra, Kevin M. Dalton"
+  url: https://doi.org/10.1063/4.0000269
+  info: Structural Dynamics, 2024
+- nickname: jackdhfr
+  section: uses
+  title: "Perturbative diffraction methods resolve a conformational switch that facilitates a two-step enzymatic mechanism"
+  authors: "**Jack B. Greisman**, Kevin M. Dalton, Dennis E. Brookner, Margaret A. Klureza, Candice J. Sheehan, In-Sik Kim, Robert W. Henning, Silvia Russi, Doeke R. Hekstra"
+  url: https://doi.org/10.1073/pnas.2313192121
+  info: PNAS, 2024
+- nickname: trxreview
+  section: uses
+  title: "Emerging Time-Resolved X-Ray Diffraction Approaches for Protein Dynamics"
+  authors: "**Doeke R. Hekstra**"
+  url: https://doi.org/10.1146/annurev-biophys-111622-091155
+  info: Annu. Rev. Biophys., 2023
+- nickname: scaling
+  section: uses
+  title: "Correcting systematic errors in diffraction data with modern scaling algorithms"
+  authors: "**Luis A. Aldama and Kevin M. Dalton**, Doeke R. Hekstra"
+  url: https://doi.org/10.1107/S2059798323005776
+  info: Acta Crystallographica D, 2023
+- nickname: neurips2022
+  section: uses
+  title: "Online Inference of Structure Factor Amplitudes for Serial X-ray Crystallography"
+  authors: "**Kevin M. Dalton** and Doeke R. Hekstra"
+  url: https://www.mlsb.io/papers_2022/Online_Inference_of_Structure_Factor_Amplitudes_for_Serial_X_ray_Crystallography.pdf
+  info: Machine Learning for Structural Biology Workshop, NeurIPS 2022
+- nickname: rtsad
+  section: uses
+  title: Native SAD phasing at room temperature
+  authors: "**Jack B. Greisman**, Kevin M. Dalton, Candice J. Sheehan, Margaret A. Klureza, Igor Kurinov, Doeke R. Hekstra"
+  url: https://doi.org/10.1107/S2059798322006799
+  info: Acta Crystallographica D, 2022

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,8 +1,26 @@
+- nickname: doublewilson
+  section: pubs
+  title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
+  authors: "**Doeke R. Hekstra**, Harrison K. Wang, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
+  url: https://doi.org/10.1126/sciadv.adj2921 
+  info: Science Advances, 2025
+- nickname: meteor
+  section: pubs
+  title: "Denoising and iterative phase recovery reveal low-occupancy populations in protein crystals"
+  authors: "**Alisia Fadini **, Virginia Apostolopoulou, Thomas J. Lane, Jasper J. van Thor"
+  url: https://doi.org/10.1038/s42003-025-09031-6
+  info: Communications Biology, 2025
+- nickname: carelessED
+  section: pubs
+  title: "Assessing the applicability of Bayesian inference for merging small molecule microED data"
+  authors: "Huanghao Mai, Ariana Peck, Kevin M. Dalton, Lygia Silva de Moraes, Jessica E. Burch, Frédéric Poitevin, Hosea M. Nelson"
+  url: https://doi.org/10.26434/chemrxiv-2024-62bmk
+  info: chemRxiv (preprint)
 - nickname: dj1
   section: pubs
   title: "Resolving DJ-I glyoxalase catalysis using mix-and-inject serial crystallography at a synchrotron"
   authors: "**Kara A. Zielinski and Cole Dolamore**, Kevin M. Dalton, Nathan Smith, John Termini, Robert Henning, Vukica Srajer, Doeke R. Hekstra, Lois Pollack, Mark A. Wilson"
-  url:  https://doi.org/10.1101/2024.07.19.604369
+  url: https://doi.org/10.1101/2024.07.19.604369
   info: bioRxiv (preprint)
 - nickname: trxvaritional
   section: pubs
@@ -10,12 +28,6 @@
   authors: "**Kara A. Zielinski**, Cole Dolamore, Harrison K. Wang, Robert W. Henning, Mark A. Wilson, Lois Pollack, Vukica Srajer, Doeke R. Hekstra, Kevin M. Dalton"
   url: https://doi.org/10.1063/4.0000269
   info: Structural Dynamics, 2024
-- nickname: doublewilson
-  section: pubs
-  title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
-  authors: "**Doeke R. Hekstra**, Harrison K. Wang, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
-  url: https://doi.org/10.1101/2024.07.22.604476 
-  info: bioRxiv (preprint)
 - nickname: lauedials
   section: cite
   package: "Laue-DIALS"

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -2,7 +2,7 @@
   section: cite
   package: "Careless"
   title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
-  authors: "**Doeke R. Hekstra**, Harrison K. Wang, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
+  authors: "**Doeke R. Hekstra**, **Harrison K. Wang**, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
   url: https://doi.org/10.1126/sciadv.adj2921 
   info: Science Advances, 2025
 - nickname: meteor

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,17 +1,20 @@
 - nickname: doublewilson
   section: cite
+  package: "Careless"
   title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
   authors: "**Doeke R. Hekstra**, Harrison K. Wang, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
   url: https://doi.org/10.1126/sciadv.adj2921 
   info: Science Advances, 2025
 - nickname: meteor
   section: cite
+  package: "meteor"
   title: "Denoising and iterative phase recovery reveal low-occupancy populations in protein crystals"
   authors: "**Alisia Fadini**, Virginia Apostolopoulou, Thomas J. Lane, Jasper J. van Thor"
   url: https://doi.org/10.1038/s42003-025-09031-6
   info: Communications Biology, 2025
 - nickname: rocket
   section: cite
+  package: "ROCKET"
   title: "AlphaFold as a Prior: Experimental Structure Determination Conditioned on a Pretrained Neural Network"
   authors: "**Alisia Fadini**, **Minhuan Li**, Airlie J. McCoy, Thomas C. Terwilliger, Randy J. Read, Doeke Hekstra, Mohammed AlQuraishi"
   url:  https://doi.org/10.1101/2025.02.18.638828 
@@ -66,49 +69,49 @@
   url: https://github.com/rs-station/rs-booster
   info: GitHub, 2025
 - nickname: carelessED
-  section: uses
+  section: applications
   title: "Assessing the applicability of Bayesian inference for merging small molecule microED data"
   authors: "Huanghao Mai, Ariana Peck, Kevin M. Dalton, Lygia Silva de Moraes, Jessica E. Burch, Frédéric Poitevin, Hosea M. Nelson"
   url: https://doi.org/10.26434/chemrxiv-2024-62bmk
   info: chemRxiv (preprint), 2024
 - nickname: dj1
-  section: uses
+  section: applications
   title: "Resolving DJ-I glyoxalase catalysis using mix-and-inject serial crystallography at a synchrotron"
   authors: "**Kara A. Zielinski and Cole Dolamore**, Kevin M. Dalton, Nathan Smith, John Termini, Robert Henning, Vukica Srajer, Doeke R. Hekstra, Lois Pollack, Mark A. Wilson"
   url:  https://doi.org/10.1101/2024.07.19.604369
   info: bioRxiv (preprint), 2024
 - nickname: trxvaritional
-  section: uses
+  section: applications
   title: "Scaling and merging time-resolved Laue data with variational inference"
   authors: "**Kara A. Zielinski**, Cole Dolamore, Harrison K. Wang, Robert W. Henning, Mark A. Wilson, Lois Pollack, Vukica Srajer, Doeke R. Hekstra, Kevin M. Dalton"
   url: https://doi.org/10.1063/4.0000269
   info: Structural Dynamics, 2024
 - nickname: jackdhfr
-  section: uses
+  section: applications
   title: "Perturbative diffraction methods resolve a conformational switch that facilitates a two-step enzymatic mechanism"
   authors: "**Jack B. Greisman**, Kevin M. Dalton, Dennis E. Brookner, Margaret A. Klureza, Candice J. Sheehan, In-Sik Kim, Robert W. Henning, Silvia Russi, Doeke R. Hekstra"
   url: https://doi.org/10.1073/pnas.2313192121
   info: PNAS, 2024
 - nickname: trxreview
-  section: uses
+  section: applications
   title: "Emerging Time-Resolved X-Ray Diffraction Approaches for Protein Dynamics"
   authors: "**Doeke R. Hekstra**"
   url: https://doi.org/10.1146/annurev-biophys-111622-091155
   info: Annu. Rev. Biophys., 2023
 - nickname: scaling
-  section: uses
+  section: applications
   title: "Correcting systematic errors in diffraction data with modern scaling algorithms"
   authors: "**Luis A. Aldama and Kevin M. Dalton**, Doeke R. Hekstra"
   url: https://doi.org/10.1107/S2059798323005776
   info: Acta Crystallographica D, 2023
 - nickname: neurips2022
-  section: uses
+  section: applications
   title: "Online Inference of Structure Factor Amplitudes for Serial X-ray Crystallography"
   authors: "**Kevin M. Dalton** and Doeke R. Hekstra"
   url: https://www.mlsb.io/papers_2022/Online_Inference_of_Structure_Factor_Amplitudes_for_Serial_X_ray_Crystallography.pdf
   info: Machine Learning for Structural Biology Workshop, NeurIPS 2022
 - nickname: rtsad
-  section: uses
+  section: applications
   title: Native SAD phasing at room temperature
   authors: "**Jack B. Greisman**, Kevin M. Dalton, Candice J. Sheehan, Margaret A. Klureza, Igor Kurinov, Doeke R. Hekstra"
   url: https://doi.org/10.1107/S2059798322006799

--- a/publications.md
+++ b/publications.md
@@ -18,7 +18,7 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 The following publications explore, expand upon, or apply RSS packages. If there's a paper we're missing, or you've recently published a paper using an RSS package, please [let us know!](/contact.html)
 
 {% for pub in site.data.publications %}
-{% if pub.section == "pubs" %}
+{% if pub.section == "uses" %}
  - [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endif %}
 {% endfor %}

--- a/publications.md
+++ b/publications.md
@@ -18,7 +18,7 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 The following publications explore, expand upon, or apply RSS packages. If there's a paper we're missing, or you've recently published a paper using an RSS package, please [let us know!](/contact.html)
 
 {% for pub in site.data.publications %}
-{% if pub.section == "uses" %}
+{% if pub.section == "applications" %}
  - [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
I went to update the publications page, and found a small issue: previously, publications were tagged as `cite` or `pubs`, indicating if they were core RSS publications or publications that use RSS packages. It turns out these slightly confusing names confused me, and also previous contributors to the website.

I changed the tag `pubs` --> `uses` in an attempt clearly indicate that those publications _use_ rss. I also sorted the YML page to separate the two categories visually.

In addition, I updated the references for:
* meteor
* double-wilson paper
* careless ED preprint

Finally, I moved the `meteor` card from "development" to "production".

This should have been 3 PRs. I hereby confess my sins to the dev gods and ask they be absolved.

