### PR TITLE
website: publications page update

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -7,7 +7,7 @@
   info: Nature Methods, 2026
 - nickname: doublewilson
   section: cite
-  package: "Double-Wilson (Careless)"
+  package: "Careless"
   title: "Sensitive detection of structural dynamics using a statistical framework for comparative crystallography"
   authors: "**Doeke R. Hekstra**, **Harrison K. Wang**, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
   url: https://doi.org/10.1126/sciadv.adj2921

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -7,7 +7,7 @@
   info: Nature Methods, 2026
 - nickname: doublewilson
   section: cite
-  package: "Careless"
+  package: "Double-Wilson (Careless)"
   title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
   authors: "**Doeke R. Hekstra**, **Harrison K. Wang**, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
   url: https://doi.org/10.1126/sciadv.adj2921

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -33,13 +33,6 @@
   authors: "**Doris Mai**, Doeke R Hekstra, Frédéric Poitevin, Kevin M Dalton"
   url: https://doi.org/10.1063/4.0000945
   info: Structural Dynamics, 2025
-- nickname: booster
-  section: cite
-  package: "RS-Booster"
-  title: "RS-Booster Repository"
-  authors: "**1 / Astronauts**"
-  url: https://github.com/rs-station/rs-booster
-  info: GitHub, 2025
 - nickname: matchmaps
   section: cite
   package: "MatchMaps"

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -29,10 +29,10 @@
 - nickname: abismal
   section: cite
   package: "ABISMAL"
-  title: "ABISMAL Repository"
-  authors: "**Kevin M. Dalton**, Huanghao Doris Mai, Doeke R. Hekstra"
-  url: https://github.com/rs-station/abismal
-  info: GitHub, 2025
+  title: "Abismal: Approximate Bayesian Inference for Scaling and Merging at Advanced Lightsources"
+  authors: "**Doris Mai**, Doeke R Hekstra, Frédéric Poitevin, Kevin M Dalton"
+  url: https://doi.org/10.1063/4.0000945
+  info: Structural Dynamics, 2025
 - nickname: booster
   section: cite
   package: "RS-Booster"

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -12,6 +12,7 @@
   authors: "**Doeke R. Hekstra**, **Harrison K. Wang**, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
   url: https://doi.org/10.1126/sciadv.adj2921
   info: Science Advances, 2025
+  footnote: "Please cite both papers when using `careless` with the Double Wilson prior."
 - nickname: meteor
   section: cite
   package: "METEOR"

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,9 +1,16 @@
+- nickname: rocket
+  section: cite
+  package: "ROCKET"
+  title: "AlphaFold as a Prior: Experimental Structure Determination Conditioned on a Pretrained Neural Network"
+  authors: "**Alisia Fadini**, **Minhuan Li**, Airlie J. McCoy, Suresh Banjara, Hiroki Okumura, Eve Napier, Pietro Fontana, Amir R. Khan, Luca Jovine, Thomas C. Terwilliger, Randy J. Read, Doeke R. Hekstra & Mohammed AlQuraishi"
+  url:  https://doi.org/10.1038/s41592-026-03047-4
+  info: Nature Methods, 2026
 - nickname: doublewilson
   section: cite
   package: "Careless"
   title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
   authors: "**Doeke R. Hekstra**, **Harrison K. Wang**, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
-  url: https://doi.org/10.1126/sciadv.adj2921 
+  url: https://doi.org/10.1126/sciadv.adj2921
   info: Science Advances, 2025
 - nickname: meteor
   section: cite
@@ -12,27 +19,27 @@
   authors: "**Alisia Fadini**, Virginia Apostolopoulou, Thomas J. Lane, Jasper J. van Thor"
   url: https://doi.org/10.1038/s42003-025-09031-6
   info: Communications Biology, 2025
-- nickname: rocket
-  section: cite
-  package: "ROCKET"
-  title: "AlphaFold as a Prior: Experimental Structure Determination Conditioned on a Pretrained Neural Network"
-  authors: "**Alisia Fadini**, **Minhuan Li**, Airlie J. McCoy, Thomas C. Terwilliger, Randy J. Read, Doeke Hekstra, Mohammed AlQuraishi"
-  url:  https://doi.org/10.1101/2025.02.18.638828 
-  info: bioRxiv (preprint), 2025
 - nickname: SFCalculator
   section: cite
   package: "SFCalculator"
   title: "SFCalculator: connecting deep generative models and crystallography"
   authors: "**Minhuan Li**, Kevin M. Dalton, Doeke R. Hekstra"
-  url: https://doi.org/10.1101/2025.01.12.632630 
+  url: https://doi.org/10.1101/2025.01.12.632630
   info: bioRxiv (preprint), 2025
-- nickname: careless
+- nickname: abismal
   section: cite
-  package: "Careless"
-  title: "A unifying Bayesian framework for merging X-ray diffraction data"
-  authors: "**Kevin M. Dalton**, Jack B. Greisman, Doeke R. Hekstra"
-  url: https://doi.org/10.1038/s41467-022-35280-8
-  info: Nature Communications, 2022
+  package: "ABISMAL"
+  title: "ABISMAL Repository"
+  authors: "**Kevin M. Dalton**, Huanghao Doris Mai, Doeke R. Hekstra"
+  url: https://github.com/rs-station/abismal
+  info: GitHub, 2025
+- nickname: booster
+  section: cite
+  package: "RS-Booster"
+  title: "RS-Booster Repository"
+  authors: "**1 / Astronauts**"
+  url: https://github.com/rs-station/rs-booster
+  info: GitHub, 2025
 - nickname: matchmaps
   section: cite
   package: "MatchMaps"
@@ -47,6 +54,13 @@
   authors: "**Rick A. Hewitt**, Kevin M. Dalton, Derek Mendez, Harrison K. Wang, Margaret A. Klureza, Dennis E. Brookner, Jack B. Greisman, David McDonagh, Vukica Šrajer, Nicholas K. Sauter, Aaron S. Brewster, Doeke R. Hekstra"
   url: https://doi.org/10.1063/4.0000265
   info: Structural Dynamics, 2024
+- nickname: careless
+  section: cite
+  package: "Careless"
+  title: "A unifying Bayesian framework for merging X-ray diffraction data"
+  authors: "**Kevin M. Dalton**, Jack B. Greisman, Doeke R. Hekstra"
+  url: https://doi.org/10.1038/s41467-022-35280-8
+  info: Nature Communications, 2022
 - nickname: rs
   section: cite
   package: "reciprocalspaceship"
@@ -54,20 +68,6 @@
   authors: "**Jack B. Greisman**, Kevin M. Dalton, Doeke R. Hekstra"
   url: https://doi.org/10.1107/S160057672100755X
   info: Journal of Applied Crystallography, 2021
-- nickname: abismal
-  section: cite
-  package: "ABISMAL"
-  title: "ABISMAL Repository"
-  authors: "**Kevin M. Dalton**, Huanghao Doris Mai, Doeke R. Hekstra"
-  url: https://github.com/rs-station/abismal 
-  info: GitHub, 2025
-- nickname: booster
-  section: cite
-  package: "RS-Booster"
-  title: "RS-Booster Repository"
-  authors: "**1 / Astronauts**"
-  url: https://github.com/rs-station/rs-booster
-  info: GitHub, 2025
 - nickname: carelessED
   section: applications
   title: "Assessing the applicability of Bayesian inference for merging small molecule microED data"

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -8,7 +8,7 @@
 - nickname: doublewilson
   section: cite
   package: "Double-Wilson (Careless)"
-  title: "Sensitive detection of structural differences using a statistical framework for comparative crystallography"
+  title: "Sensitive detection of structural dynamics using a statistical framework for comparative crystallography"
   authors: "**Doeke R. Hekstra**, **Harrison K. Wang**, Margaret A. Klureza, Jack B. Greisman, Kevin M. Dalton"
   url: https://doi.org/10.1126/sciadv.adj2921
   info: Science Advances, 2025
@@ -44,7 +44,7 @@
   section: cite
   package: "Laue-DIALS"
   title: "Laue-DIALS: open-source software for polychromatic X-ray diffraction data"
-  authors: "**Rick A. Hewitt**, Kevin M. Dalton, Derek Mendez, Harrison K. Wang, Margaret A. Klureza, Dennis E. Brookner, Jack B. Greisman, David McDonagh, Vukica Šrajer, Nicholas K. Sauter, Aaron S. Brewster, Doeke R. Hekstra"
+  authors: "**Rick A. Hewitt**, Kevin M. Dalton, Derek A. Mendez, Harrison K. Wang, Margaret A. Klureza, Dennis E. Brookner, Jack B. Greisman, David McDonagh, Vukica Šrajer, Nicholas K. Sauter, Aaron S. Brewster, Doeke R. Hekstra"
   url: https://doi.org/10.1063/4.0000265
   info: Structural Dynamics, 2024
 - nickname: careless
@@ -69,13 +69,13 @@
   info: chemRxiv (preprint), 2024
 - nickname: dj1
   section: applications
-  title: "Resolving DJ-I glyoxalase catalysis using mix-and-inject serial crystallography at a synchrotron"
+  title: "Resolving DJ-1 glyoxalase catalysis using mix-and-inject serial crystallography at a synchrotron"
   authors: "**Kara A. Zielinski and Cole Dolamore**, Kevin M. Dalton, Nathan Smith, John Termini, Robert Henning, Vukica Srajer, Doeke R. Hekstra, Lois Pollack, Mark A. Wilson"
   url:  https://doi.org/10.1101/2024.07.19.604369
   info: bioRxiv (preprint), 2024
 - nickname: trxvaritional
   section: applications
-  title: "Scaling and merging time-resolved Laue data with variational inference"
+  title: "Scaling and merging time-resolved pink-beam diffraction with variational inference"
   authors: "**Kara A. Zielinski**, Cole Dolamore, Harrison K. Wang, Robert W. Henning, Mark A. Wilson, Lois Pollack, Vukica Srajer, Doeke R. Hekstra, Kevin M. Dalton"
   url: https://doi.org/10.1063/4.0000269
   info: Structural Dynamics, 2024

--- a/publications.md
+++ b/publications.md
@@ -6,11 +6,10 @@ layout: content_page
 # Citing Reciprocal Space Station packages
 If you're making use of any RSS packages, amazing! Please cite them as follows:
 
-{% for pub in site.data.publications %}
-{% if pub.section == "cite" %}
+{% assign cite_pubs = site.data.publications | where: "section", "cite" | sort_natural: "package" %}
+{% for pub in cite_pubs %}
 ### {{ pub.package }}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
-{% endif %}
 {% endfor %}
 
 

--- a/publications.md
+++ b/publications.md
@@ -8,7 +8,6 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 
 {% assign cite_pubs = site.data.publications | where: "section", "cite" | sort_natural: "package" | group_by: "package" %}
 {% for group in cite_pubs %}
-### {{ group.name }}
 {% for pub in group.items %}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}

--- a/publications.md
+++ b/publications.md
@@ -11,9 +11,9 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 {% for pub in group.items %}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}
-{% if group.name == "Careless" %}
-<small>Please cite both papers when using `careless` with the Double Wilson prior.</small>
-{% endif %}
+{% for pub in group.items %}{% if pub.footnote %}
+<small>{{ pub.footnote }}</small>
+{% endif %}{% endfor %}
 {% endfor %}
 
 

--- a/publications.md
+++ b/publications.md
@@ -6,10 +6,12 @@ layout: content_page
 # Citing Reciprocal Space Station packages
 If you're making use of any RSS packages, amazing! Please cite them as follows:
 
-{% assign cite_pubs = site.data.publications | where: "section", "cite" | sort_natural: "package" %}
-{% for pub in cite_pubs %}
-### {{ pub.package }}
+{% assign cite_pubs = site.data.publications | where: "section", "cite" | sort_natural: "package" | group_by: "package" %}
+{% for group in cite_pubs %}
+### {{ group.name }}
+{% for pub in group.items %}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
+{% endfor %}
 {% endfor %}
 
 

--- a/publications.md
+++ b/publications.md
@@ -12,6 +12,9 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 {% for pub in group.items %}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}
+{% if group.name == "Careless" %}
+<small>Please cite both papers when using `careless` with the Double Wilson prior.</small>
+{% endif %}
 {% endfor %}
 
 

--- a/publications.md
+++ b/publications.md
@@ -8,6 +8,7 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 
 {% assign cite_pubs = site.data.publications | where: "section", "cite" | sort_natural: "package" | group_by: "package" %}
 {% for group in cite_pubs %}
+### {{ pub.package }}
 {% for pub in group.items %}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}

--- a/publications.md
+++ b/publications.md
@@ -8,7 +8,7 @@ If you're making use of any RSS packages, amazing! Please cite them as follows:
 
 {% assign cite_pubs = site.data.publications | where: "section", "cite" | sort_natural: "package" | group_by: "package" %}
 {% for group in cite_pubs %}
-### {{ pub.package }}
+### {{ group.name }}
 {% for pub in group.items %}
 [{{ pub.title }}]({{ pub.url}}). {{ pub.authors }}. *{{ pub.info }}*
 {% endfor %}


### PR DESCRIPTION
# Website citation update
- Reorder publication cards in reverse chronological order (newest first) across both cite and applications sections
- Update ROCKET entry: published in Nature Methods 2026 (was bioRxiv preprint), updated DOI, expanded author list
- Update ABISMAL entry: now published in Structural Dynamics with proper title/authors/DOI (was GitHub placeholder)
- Rename Careless package to "Double-Wilson (Careless)" for the doublewilson entry
- Remove RS-Booster placeholder entry (not a publication)
- Fix metadata errors verified against CrossRef DOIs:
  - doublewilson: "structural differences" → "structural dynamics"
  - dj1: "DJ-I" → "DJ-1"
  - trxvaritional: "time-resolved Laue data" → "time-resolved pink-beam diffraction"
  - lauedials: "Derek Mendez" → "Derek A. Mendez"