### PR TITLE
add team page

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -2,6 +2,8 @@
   link: /
 - name: About
   link: /about.html
+- name: Team
+  link: /team.html
 - name: Software
   link: /software.html
 - name: Contact

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -31,3 +31,8 @@
   affiliation: Johns Hopkins University
   link: https://luhuanwu.github.io/
   github: LuhuanWu
+- name: Pilar Cossio
+  title: Senior Research Scientist
+  affiliation: Flatiron Institute
+  link: https://pilarcossio.org/
+  github: picossio

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -4,8 +4,8 @@
   link: https://hekstralab.fas.harvard.edu/
   github: DHekstra
 - name: TJ Lane
-  title: Group Leader
-  affiliation: Deutsches Elektronen-Synchrotron “DESY”
+  title: Photobiology (PBIO) Group Leader
+  affiliation: Deutsches Elektronen-Synchrotron, DESY
   link: https://tjlane.github.io/
   github: tjlane
 - name: Mohammed AlQuraishi
@@ -27,7 +27,7 @@
   link: https://minhuanli.github.io/
   github: minhuanli
 - name: Luhuan Wu
-  title: Center for Computational Mathematics (CCM) Associate Research Scientist
-  affiliation: Flatiron Institute
+  title: Assistant Professor of Applied Mathematics and Statistics
+  affiliation: Johns Hopkins University
   link: https://luhuanwu.github.io/
   github: LuhuanWu

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -9,7 +9,7 @@
   link: https://tjlane.github.io/
   github: tjlane
 - name: Mohammed AlQuraishi
-  title: Assistant Professor of Systems Biology (in Computer Science), Department Systems Biology
+  title: Assistant Professor of Systems Biology (in Computer Science)
   affiliation: Columbia University
   link: https://www.aqlab.io/
   github: alquraishi

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,0 +1,33 @@
+- name: Doeke Hekstra
+  title: Associate Professor of Molecular and Cellular Biology and Applied Physics
+  affiliation: Harvard University
+  link: https://hekstralab.fas.harvard.edu/
+  github: DHekstra
+- name: TJ Lane
+  title: Group Leader
+  affiliation: Deutsches Elektronen-Synchrotron “DESY”
+  link: https://tjlane.github.io/
+  github: tjlane
+- name: Mohammed AlQuraishi
+  title: Assistant Professor of Systems Biology (in Computer Science), Department Systems Biology
+  affiliation: Columbia University
+  link: https://www.aqlab.io/
+  github: alquraishi
+- name: Kevin Dalton
+  title: Associate Staff Scientist in Experimental Data Systems
+  affiliation: Linac Coherent Light Source at SLAC National Accelerator Laboratory
+  github: kmdalton
+- name: Alisia Fadini
+  title: Department of Systems Biology Postdoctoral Fellow
+  affiliation: Columbia University
+  github: alisiafadini
+- name: Minhuan Li
+  title: Center for Computational Mathematics (CCM) Research Fellow
+  affiliation: Flatiron Institute
+  link: https://minhuanli.github.io/
+  github: minhuanli
+- name: Luhuan Wu
+  title: Center for Computational Mathematics (CCM) Associate Research Scientist
+  affiliation: Flatiron Institute
+  link: https://luhuanwu.github.io/
+  github: LuhuanWu

--- a/_includes/team_cards.html
+++ b/_includes/team_cards.html
@@ -1,0 +1,40 @@
+<div class="row gx-4 gx-lg-5 justify-content-center" id="team-grid">
+
+    {% for member in site.data.team %}
+        {% if member.link %}{% assign target = member.link %}{% else %}{% assign target = "https://github.com/" | append: member.github %}{% endif %}
+        <div class="col-sm-6 col-lg-4 mb-4">
+            <a class="team-card-link" href="{{ target }}">
+                <div class="card h-100 text-center">
+                    <div class="card-body">
+                        {% if member.photo %}
+                        <img class="team-avatar rounded-circle mb-3" src="{{ member.photo | relative_url }}" alt="{{ member.name }}">
+                        {% else %}
+                        <img class="team-avatar rounded-circle mb-3" src="https://github.com/{{ member.github }}.png" alt="{{ member.name }}">
+                        {% endif %}
+                        <h3 class="card-title">{{ member.name }}</h3>
+                        <p class="card-text">
+                            <strong>{{ member.title }}</strong><br>
+                            {{ member.affiliation }}
+                        </p>
+                    </div>
+                </div>
+            </a>
+        </div>
+    {% endfor %}
+
+</div>
+
+<script>
+    // Shuffle the team cards on each visit (Fisher–Yates) so no one is
+    // perpetually listed first.
+    (function () {
+        var grid = document.getElementById('team-grid');
+        if (!grid) return;
+        var cards = Array.prototype.slice.call(grid.children);
+        for (var i = cards.length - 1; i > 0; i--) {
+            var j = Math.floor(Math.random() * (i + 1));
+            var tmp = cards[i]; cards[i] = cards[j]; cards[j] = tmp;
+        }
+        cards.forEach(function (card) { grid.appendChild(card); });
+    })();
+</script>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -193,6 +193,19 @@ a:hover:not([class]) {
   border-top: 1px solid #e5e7eb;
 }
 
+/* ── Team cards ── */
+.team-card-link {
+  display: block;
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+.team-avatar {
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+}
+
 /* ── Scrollspy sidebar ── */
 .toc-sidebar {
   padding-top: 0.5rem;

--- a/team.md
+++ b/team.md
@@ -1,0 +1,9 @@
+---
+title: Team
+layout: content_page
+---
+
+# Core Team
+
+{% include team_cards.html %}
+

--- a/team.md
+++ b/team.md
@@ -1,9 +1,13 @@
 ---
 title: Team
-layout: content_page
+layout: base_page
 ---
 
-# Core Team
+<div class="mt-4 mb-5" markdown="1">
+
+# Core Developers
 
 {% include team_cards.html %}
+
+</div>
 

--- a/team.md
+++ b/team.md
@@ -5,7 +5,7 @@ layout: base_page
 
 <div class="mt-4 mb-5" markdown="1">
 
-# Core Developers
+# Core Team Members
 
 {% include team_cards.html %}
 


### PR DESCRIPTION
Draft addition of a "team" page with cards. Of note
 - Images are pulled from GitHub user account
 - Links are to GitHub profiles unless overridden with the "link" metadatum
 - Cards are randomized on loading