### PR TITLE
Add automated Community Developers section to Team page

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,0 +1,50 @@
+name: Update community contributors
+
+on:
+  # Refresh daily at 06:00 UTC
+  schedule:
+    - cron: "0 6 * * *"
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write   # commit the regenerated data file
+  actions: write    # dispatch the build_and_deploy workflow
+
+concurrency:
+  group: "update-contributors"
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Regenerate contributors data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/fetch_contributors.py
+
+      - name: Commit and redeploy if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$(git status --porcelain _data/contributors.json)" ]; then
+            echo "No contributor changes; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add _data/contributors.json
+          git commit -m "data: refresh community contributors"
+          git push
+          # A push made with GITHUB_TOKEN does not trigger build_and_deploy
+          # (loop-prevention), so dispatch it explicitly to redeploy with fresh data.
+          gh workflow run build_and_deploy.yml

--- a/_data/contributors.json
+++ b/_data/contributors.json
@@ -1,0 +1,128 @@
+[
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/6944142?v=4",
+    "contributions": 1233,
+    "html_url": "https://github.com/JBGreisman",
+    "login": "JBGreisman",
+    "name": "Jack Greisman"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/61811696?v=4",
+    "contributions": 514,
+    "html_url": "https://github.com/dennisbrookner",
+    "login": "dennisbrookner",
+    "name": "Dennis Brookner"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/16063902?v=4",
+    "contributions": 464,
+    "html_url": "https://github.com/PrinceWalnut",
+    "login": "PrinceWalnut",
+    "name": "Rick Hewitt"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/163336234?v=4",
+    "contributions": 27,
+    "html_url": "https://github.com/flavia122",
+    "login": "flavia122",
+    "name": "Flavia Giehr"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/145164963?v=4",
+    "contributions": 21,
+    "html_url": "https://github.com/andrewc28",
+    "login": "andrewc28",
+    "name": "andrewc28"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/98353449?v=4",
+    "contributions": 20,
+    "html_url": "https://github.com/hkwang",
+    "login": "hkwang",
+    "name": "hkwang"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/67402286?v=4",
+    "contributions": 19,
+    "html_url": "https://github.com/LuisA92",
+    "login": "LuisA92",
+    "name": "Luis Alberto Aldama"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/50203100?v=4",
+    "contributions": 16,
+    "html_url": "https://github.com/cvazz",
+    "login": "cvazz",
+    "name": "Sebastian Bielfeldt"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/3398263?v=4",
+    "contributions": 8,
+    "html_url": "https://github.com/jorenretel",
+    "login": "jorenretel",
+    "name": "Joren Retel"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/26993978?v=4",
+    "contributions": 6,
+    "html_url": "https://github.com/DorisMai",
+    "login": "DorisMai",
+    "name": "Doris Mai"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/2335439?v=4",
+    "contributions": 4,
+    "html_url": "https://github.com/dermen",
+    "login": "dermen",
+    "name": "Derek Mendez"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/10111092?v=4",
+    "contributions": 2,
+    "html_url": "https://github.com/ianhi",
+    "login": "ianhi",
+    "name": "Ian Hunt-Isaak"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/6155533?v=4",
+    "contributions": 2,
+    "html_url": "https://github.com/jrobsontull",
+    "login": "jrobsontull",
+    "name": "Jake Robson-Tull"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/2102431?v=4",
+    "contributions": 1,
+    "html_url": "https://github.com/Anthchirp",
+    "login": "Anthchirp",
+    "name": "Markus Gerstel"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/154796512?v=4",
+    "contributions": 1,
+    "html_url": "https://github.com/Daisylbh",
+    "login": "Daisylbh",
+    "name": "Daisy Liu"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/1899768?v=4",
+    "contributions": 1,
+    "html_url": "https://github.com/jglaser",
+    "login": "jglaser",
+    "name": "jglaser"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/169851672?v=4",
+    "contributions": 1,
+    "html_url": "https://github.com/jrthornton",
+    "login": "jrthornton",
+    "name": "jrthornton"
+  },
+  {
+    "avatar_url": "https://avatars.githubusercontent.com/u/3790706?v=4",
+    "contributions": 1,
+    "html_url": "https://github.com/virginia4",
+    "login": "virginia4",
+    "name": "virginia4"
+  }
+]

--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -2,6 +2,8 @@
   link: /
 - name: About
   link: /about.html
+- name: Team
+  link: /team.html
 - name: Software
   link: /software.html
 - name: Contact

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -4,8 +4,8 @@
   link: https://hekstralab.fas.harvard.edu/
   github: DHekstra
 - name: TJ Lane
-  title: Group Leader
-  affiliation: Deutsches Elektronen-Synchrotron “DESY”
+  title: Photobiology (PBIO) Group Leader
+  affiliation: Deutsches Elektronen-Synchrotron, DESY
   link: https://tjlane.github.io/
   github: tjlane
 - name: Mohammed AlQuraishi
@@ -27,7 +27,7 @@
   link: https://minhuanli.github.io/
   github: minhuanli
 - name: Luhuan Wu
-  title: Center for Computational Mathematics (CCM) Associate Research Scientist
-  affiliation: Flatiron Institute
+  title: Assistant Professor of Applied Mathematics and Statistics
+  affiliation: Johns Hopkins University
   link: https://luhuanwu.github.io/
   github: LuhuanWu

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -9,7 +9,7 @@
   link: https://tjlane.github.io/
   github: tjlane
 - name: Mohammed AlQuraishi
-  title: Assistant Professor of Systems Biology (in Computer Science), Department Systems Biology
+  title: Assistant Professor of Systems Biology (in Computer Science)
   affiliation: Columbia University
   link: https://www.aqlab.io/
   github: alquraishi

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -31,3 +31,9 @@
   affiliation: Johns Hopkins University
   link: https://luhuanwu.github.io/
   github: LuhuanWu
+- name: Pilar Cossio
+  title: Senior Research Scientist
+  affiliation: Flatiron Institute
+  link: https://pilarcossio.org/
+  github: picossio
+

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,0 +1,33 @@
+- name: Doeke Hekstra
+  title: Associate Professor of Molecular and Cellular Biology and Applied Physics
+  affiliation: Harvard University
+  link: https://hekstralab.fas.harvard.edu/
+  github: DHekstra
+- name: TJ Lane
+  title: Group Leader
+  affiliation: Deutsches Elektronen-Synchrotron “DESY”
+  link: https://tjlane.github.io/
+  github: tjlane
+- name: Mohammed AlQuraishi
+  title: Assistant Professor of Systems Biology (in Computer Science), Department Systems Biology
+  affiliation: Columbia University
+  link: https://www.aqlab.io/
+  github: alquraishi
+- name: Kevin Dalton
+  title: Associate Staff Scientist in Experimental Data Systems
+  affiliation: Linac Coherent Light Source at SLAC National Accelerator Laboratory
+  github: kmdalton
+- name: Alisia Fadini
+  title: Department of Systems Biology Postdoctoral Fellow
+  affiliation: Columbia University
+  github: alisiafadini
+- name: Minhuan Li
+  title: Center for Computational Mathematics (CCM) Research Fellow
+  affiliation: Flatiron Institute
+  link: https://minhuanli.github.io/
+  github: minhuanli
+- name: Luhuan Wu
+  title: Center for Computational Mathematics (CCM) Associate Research Scientist
+  affiliation: Flatiron Institute
+  link: https://luhuanwu.github.io/
+  github: LuhuanWu

--- a/_includes/community_cards.html
+++ b/_includes/community_cards.html
@@ -1,0 +1,35 @@
+<div class="row gx-4 gx-lg-5 justify-content-center" id="community-grid">
+
+    {% for c in site.data.contributors %}
+        <div class="col-sm-6 col-lg-4 mb-4">
+            <a class="team-card-link" href="{{ c.html_url }}">
+                <div class="card h-100 text-center">
+                    <div class="card-body">
+                        <img class="team-avatar rounded-circle mb-3" src="{{ c.avatar_url }}" alt="{{ c.name | default: c.login }}">
+                        <h3 class="card-title">{{ c.name | default: c.login }}</h3>
+                        <p class="card-text">
+                            <strong>@{{ c.login }}</strong><br>
+                            {{ c.contributions }} contributions
+                        </p>
+                    </div>
+                </div>
+            </a>
+        </div>
+    {% endfor %}
+
+</div>
+
+<script>
+    // Shuffle the community cards on each visit (Fisher–Yates), matching the
+    // core team grid, so the contribution-count order isn't read as a ranking.
+    (function () {
+        var grid = document.getElementById('community-grid');
+        if (!grid) return;
+        var cards = Array.prototype.slice.call(grid.children);
+        for (var i = cards.length - 1; i > 0; i--) {
+            var j = Math.floor(Math.random() * (i + 1));
+            var tmp = cards[i]; cards[i] = cards[j]; cards[j] = tmp;
+        }
+        cards.forEach(function (card) { grid.appendChild(card); });
+    })();
+</script>

--- a/_includes/team_cards.html
+++ b/_includes/team_cards.html
@@ -1,0 +1,40 @@
+<div class="row gx-4 gx-lg-5 justify-content-center" id="team-grid">
+
+    {% for member in site.data.team %}
+        {% if member.link %}{% assign target = member.link %}{% else %}{% assign target = "https://github.com/" | append: member.github %}{% endif %}
+        <div class="col-sm-6 col-lg-4 mb-4">
+            <a class="team-card-link" href="{{ target }}">
+                <div class="card h-100 text-center">
+                    <div class="card-body">
+                        {% if member.photo %}
+                        <img class="team-avatar rounded-circle mb-3" src="{{ member.photo | relative_url }}" alt="{{ member.name }}">
+                        {% else %}
+                        <img class="team-avatar rounded-circle mb-3" src="https://github.com/{{ member.github }}.png" alt="{{ member.name }}">
+                        {% endif %}
+                        <h3 class="card-title">{{ member.name }}</h3>
+                        <p class="card-text">
+                            <strong>{{ member.title }}</strong><br>
+                            {{ member.affiliation }}
+                        </p>
+                    </div>
+                </div>
+            </a>
+        </div>
+    {% endfor %}
+
+</div>
+
+<script>
+    // Shuffle the team cards on each visit (Fisher–Yates) so no one is
+    // perpetually listed first.
+    (function () {
+        var grid = document.getElementById('team-grid');
+        if (!grid) return;
+        var cards = Array.prototype.slice.call(grid.children);
+        for (var i = cards.length - 1; i > 0; i--) {
+            var j = Math.floor(Math.random() * (i + 1));
+            var tmp = cards[i]; cards[i] = cards[j]; cards[j] = tmp;
+        }
+        cards.forEach(function (card) { grid.appendChild(card); });
+    })();
+</script>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -193,6 +193,19 @@ a:hover:not([class]) {
   border-top: 1px solid #e5e7eb;
 }
 
+/* ── Team cards ── */
+.team-card-link {
+  display: block;
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+.team-avatar {
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+}
+
 /* ── Scrollspy sidebar ── */
 .toc-sidebar {
   padding-top: 0.5rem;

--- a/scripts/fetch_contributors.py
+++ b/scripts/fetch_contributors.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Aggregate contributors across all public rs-station repos into _data/contributors.json.
+
+Uses only the Python standard library. Reads an optional GITHUB_TOKEN from the
+environment to raise the API rate limit (the data itself is public, so a token is
+not required — unauthenticated runs just hit the 60 req/hr limit).
+
+Run locally with:  GITHUB_TOKEN=$(gh auth token) python3 scripts/fetch_contributors.py
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+ORG = "rs-station"
+API = "https://api.github.com"
+
+# Repo root is the parent of this script's directory.
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEAM_YML = os.path.join(ROOT, "_data", "team.yml")
+OUT_PATH = os.path.join(ROOT, "_data", "contributors.json")
+
+# Bot accounts that aren't flagged as type=="Bot" or suffixed with "[bot]".
+BOT_DENYLIST = {
+    "renovate-bot",
+    "copilot",
+    "dependabot",
+    "github-actions",
+    "pre-commit-ci",
+    "allcontributors",
+}
+
+
+def gh_get(path):
+    """GET an absolute or API-relative GitHub URL, returning parsed JSON."""
+    url = path if path.startswith("http") else API + path
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "rs-station-contributors-script")
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req) as resp:
+        return json.load(resp)
+
+
+def paginate(path):
+    """Yield items across all pages of a list endpoint."""
+    page = 1
+    sep = "&" if "?" in path else "?"
+    while True:
+        batch = gh_get(f"{path}{sep}per_page=100&page={page}")
+        if not batch:
+            break
+        for item in batch:
+            yield item
+        if len(batch) < 100:
+            break
+        page += 1
+
+
+def core_logins():
+    """Logins listed in _data/team.yml (lowercased), parsed without PyYAML."""
+    logins = set()
+    try:
+        with open(TEAM_YML, encoding="utf-8") as fh:
+            for line in fh:
+                m = re.match(r"\s*github:\s*(\S+)", line)
+                if m:
+                    logins.add(m.group(1).strip().strip("\"'").lower())
+    except FileNotFoundError:
+        pass
+    return logins
+
+
+def is_bot(login, ctype):
+    login_l = login.lower()
+    return ctype == "Bot" or login_l.endswith("[bot]") or login_l in BOT_DENYLIST
+
+
+def main():
+    excluded = core_logins()
+    # login -> aggregated record
+    people = {}
+
+    for repo in paginate(f"/orgs/{ORG}/repos?type=public"):
+        if repo.get("fork"):
+            continue
+        name = repo["name"]
+        try:
+            contributors = list(paginate(f"/repos/{ORG}/{name}/contributors?anon=0"))
+        except urllib.error.HTTPError as e:
+            # Empty repos return 204/no contributors; skip quietly.
+            print(f"  skipping {name}: {e}", file=sys.stderr)
+            continue
+        for c in contributors:
+            login = c.get("login")
+            if not login or is_bot(login, c.get("type", "")):
+                continue
+            if login.lower() in excluded:
+                continue
+            rec = people.setdefault(
+                login,
+                {
+                    "login": login,
+                    "avatar_url": c.get("avatar_url", ""),
+                    "html_url": c.get("html_url", ""),
+                    "contributions": 0,
+                },
+            )
+            rec["contributions"] += c.get("contributions", 0)
+
+    # Resolve display names (best effort).
+    for login, rec in people.items():
+        try:
+            user = gh_get(f"/users/{login}")
+            rec["name"] = user.get("name") or login
+        except urllib.error.HTTPError:
+            rec["name"] = login
+
+    ordered = sorted(
+        people.values(), key=lambda r: (-r["contributions"], r["login"].lower())
+    )
+
+    with open(OUT_PATH, "w", encoding="utf-8") as fh:
+        json.dump(ordered, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+    print(f"Wrote {len(ordered)} contributors to {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/team.md
+++ b/team.md
@@ -1,0 +1,9 @@
+---
+title: Team
+layout: content_page
+---
+
+# Core Team
+
+{% include team_cards.html %}
+

--- a/team.md
+++ b/team.md
@@ -9,5 +9,11 @@ layout: base_page
 
 {% include team_cards.html %}
 
+# Community Developers
+
+Everyone who has contributed code to an rs-station repository. Thank you! 🎉
+
+{% include community_cards.html %}
+
 </div>
 

--- a/team.md
+++ b/team.md
@@ -1,9 +1,13 @@
 ---
 title: Team
-layout: content_page
+layout: base_page
 ---
 
-# Core Team
+<div class="mt-4 mb-5" markdown="1">
+
+# Core Developers
 
 {% include team_cards.html %}
+
+</div>
 

--- a/team.md
+++ b/team.md
@@ -5,7 +5,7 @@ layout: base_page
 
 <div class="mt-4 mb-5" markdown="1">
 
-# Core Developers
+# Core Team Members
 
 {% include team_cards.html %}
 


### PR DESCRIPTION
## What

Adds a **Community Developers** section to the Team page listing everyone who has contributed code to a public rs-station repository, alongside the existing Core Developers cards.

## How it works

- **`scripts/fetch_contributors.py`** — stdlib-only script that aggregates contributors across all public, non-fork org repos. It filters out bots and anyone already listed as a core developer in `_data/team.yml`, resolves display names, and writes `_data/contributors.json` sorted by contribution count (for stable diffs).
- **`_includes/community_cards.html`** — renders the contributor cards (avatar, name, `@login`, contribution count), reusing the existing card styling. Cards are **shuffled client-side on each visit** so the contribution order isn't read as a ranking.
- **`.github/workflows/update_contributors.yml`** — runs daily (and on demand), regenerates the data, commits only when it changes, then dispatches `build_and_deploy` to redeploy.

## Why no PAT is needed

Org membership is mostly private, but **contributor data for public repos is public**. The workflow uses the auto-provided `GITHUB_TOKEN` purely to raise the API rate limit. Private-repo contributors are intentionally not included.

## Setup note

For the scheduled workflow to push commits and dispatch the deploy, the repo needs **Settings → Actions → General → Workflow permissions** set to **Read and write permissions**.

## Verification

- Ran the script locally → 18 contributors (core team and bots excluded).
- `bundle exec jekyll build` succeeds; the Team page renders both sections, with correct contribution counts and GitHub profile links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)