### PR TITLE
Fix homepage navbar overlapping the brand on scroll

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -392,6 +392,7 @@ body.hero-page .navbar-brand {
   transition: opacity 0.35s ease;
 }
 body.hero-page .navbar.navbar-scrolled .navbar-brand {
+  position: static;   /* back in flow so it claims space and the nav sits to its right */
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Problem

On the homepage, scrolling down fades in the brand (logo + "Reciprocal Space Station") top-left, but at desktop width (≥1200px) the nav tabs stay spread across the bar and **overlap the brand text** instead of dodging to the right.

## Cause

`body.hero-page .navbar-brand` is `position: absolute` in both scroll states; the `.navbar-scrolled` rule only changed `opacity`. So when scrolled, the brand becomes visible while still *out of flow*, and the (wide) right-aligned nav stretches back across the container on top of it. The `<1200px` block already avoids this by using `position: static`.

## Fix

Add `position: static` to the scrolled-brand rule so it claims layout space; the flex nav then naturally sits to its right. One line, desktop-only path; the at-top (transparent, centered-nav) state is unchanged.

## Verification

- `bundle exec jekyll build` succeeds; rule present in output.
- Please eyeball the **preview deploy** on this PR: scroll the homepage past the hero and confirm the brand appears top-left with the tabs to its right (no overlap), and that the top-of-page centered-nav look is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)